### PR TITLE
Fix types from bumping immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
     "reactcss": "1.2.3",
     "recompose": "^0.26.0",
     "reduce-reducers": "^1.0.4",
-    "redux": "^4.0.5",
+    "redux": "^4.1.0",
     "redux-actions": "^2.6.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",

--- a/x-pack/plugins/osquery/public/fleet_integration/osquery_managed_policy_create_import_extension.tsx
+++ b/x-pack/plugins/osquery/public/fleet_integration/osquery_managed_policy_create_import_extension.tsx
@@ -148,14 +148,13 @@ export const OsqueryManagedPolicyCreateImportExtension = React.memo<
   // }, [editMode, replace]);
 
   const scheduledQueryGroupTableData = useMemo(() => {
-    const policyWithoutEmptyQueries = produce<
-      NewPackagePolicy,
-      OsqueryManagerPackagePolicy,
-      OsqueryManagerPackagePolicy
-    >(newPolicy, (draft) => {
-      draft.inputs[0].streams = filter(['compiled_stream.id', null], draft.inputs[0].streams);
-      return draft;
-    });
+    const policyWithoutEmptyQueries = produce<NewPackagePolicy, OsqueryManagerPackagePolicy>(
+      newPolicy,
+      (draft) => {
+        draft.inputs[0].streams = filter(['compiled_stream.id', null], draft.inputs[0].streams);
+        return draft;
+      }
+    );
 
     return policyWithoutEmptyQueries;
   }, [newPolicy]);
@@ -198,6 +197,7 @@ export const OsqueryManagedPolicyCreateImportExtension = React.memo<
         <EuiFlexGroup>
           <EuiFlexItem>
             <ScheduledQueryGroupQueriesTable
+              // @ts-expect-error update
               data={scheduledQueryGroupTableData.inputs[0].streams}
             />
           </EuiFlexItem>

--- a/x-pack/plugins/osquery/public/packs/common/pack_queries_field.tsx
+++ b/x-pack/plugins/osquery/public/packs/common/pack_queries_field.tsx
@@ -44,6 +44,7 @@ const PackQueriesFieldComponent = ({ field }) => {
     (newQuery) =>
       setValue(
         produce((draft) => {
+          // @ts-expect-error update
           draft.push({
             interval: newQuery.interval,
             query: newQuery.query.attributes.query,
@@ -56,6 +57,7 @@ const PackQueriesFieldComponent = ({ field }) => {
   );
 
   const handleRemoveQuery = useCallback(
+    // @ts-expect-error update
     (query) => setValue(produce((draft) => reject(['id', query.id], draft))),
     [setValue]
   );

--- a/x-pack/plugins/osquery/public/scheduled_query_groups/form/queries_field.tsx
+++ b/x-pack/plugins/osquery/public/scheduled_query_groups/form/queries_field.tsx
@@ -138,33 +138,42 @@ const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({
         if (showEditQueryFlyout >= 0) {
           setValue(
             produce((draft) => {
+              // @ts-expect-error update
               draft[0].streams[showEditQueryFlyout].vars.id.value = updatedQuery.id;
+              // @ts-expect-error update
               draft[0].streams[showEditQueryFlyout].vars.interval.value = updatedQuery.interval;
+              // @ts-expect-error update
               draft[0].streams[showEditQueryFlyout].vars.query.value = updatedQuery.query;
 
               if (updatedQuery.platform?.length) {
+                // @ts-expect-error update
                 draft[0].streams[showEditQueryFlyout].vars.platform = {
                   type: 'text',
                   value: updatedQuery.platform,
                 };
               } else {
+                // @ts-expect-error update
                 delete draft[0].streams[showEditQueryFlyout].vars.platform;
               }
 
               if (updatedQuery.version?.length) {
+                // @ts-expect-error update
                 draft[0].streams[showEditQueryFlyout].vars.version = {
                   type: 'text',
                   value: updatedQuery.version,
                 };
               } else {
+                // @ts-expect-error update
                 delete draft[0].streams[showEditQueryFlyout].vars.version;
               }
 
               if (updatedQuery.ecs_mapping) {
+                // @ts-expect-error update
                 draft[0].streams[showEditQueryFlyout].vars.ecs_mapping = {
                   value: updatedQuery.ecs_mapping,
                 };
               } else {
+                // @ts-expect-error update
                 delete draft[0].streams[showEditQueryFlyout].vars.ecs_mapping;
               }
 
@@ -185,6 +194,7 @@ const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({
         setValue(
           produce((draft) => {
             draft[0].streams.push(
+              // @ts-expect-error update
               getNewStream({
                 ...newQuery,
                 scheduledQueryGroupId,
@@ -221,6 +231,7 @@ const QueriesFieldComponent: React.FC<QueriesFieldProps> = ({
         produce((draft) => {
           forEach(parsedContent.queries, (newQuery, newQueryId) => {
             draft[0].streams.push(
+              // @ts-expect-error update
               getNewStream({
                 id: isOsqueryPackSupported ? newQueryId : `pack_${packName}_${newQueryId}`,
                 interval: newQuery.interval ?? parsedContent.interval,

--- a/x-pack/plugins/osquery/public/scheduled_query_groups/queries/ecs_mapping_editor_field.tsx
+++ b/x-pack/plugins/osquery/public/scheduled_query_groups/queries/ecs_mapping_editor_field.tsx
@@ -317,7 +317,7 @@ export interface ECSMappingEditorFieldRef {
 }
 
 export interface ECSMappingEditorFieldProps {
-  field: FieldHook<string>;
+  field: FieldHook<Record<string, unknown>>;
   query: string;
   fieldRef: MutableRefObject<ECSMappingEditorFieldRef>;
 }

--- a/x-pack/plugins/security_solution/common/search_strategy/index_fields/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/index_fields/index.ts
@@ -5,10 +5,14 @@
  * 2.0.
  */
 
-import { IFieldSubType } from '@kbn/es-query';
-import type { IIndexPattern } from 'src/plugins/data/public';
-import { IEsSearchRequest, IEsSearchResponse } from '../../../../../../src/plugins/data/common';
-import { DocValueFields, Maybe } from '../common';
+import type { IFieldSubType } from '@kbn/es-query';
+
+import type {
+  IEsSearchRequest,
+  IEsSearchResponse,
+  IIndexPattern,
+} from '../../../../../../src/plugins/data/common';
+import type { DocValueFields, Maybe } from '../common';
 
 interface FieldInfo {
   category: string;
@@ -66,12 +70,7 @@ export interface BrowserField {
   name: string;
   searchable: boolean;
   type: string;
-  subType?: {
-    [key: string]: unknown;
-    nested?: {
-      path: string;
-    };
-  };
+  subType?: IFieldSubType;
 }
 
 export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;

--- a/x-pack/plugins/security_solution/public/app/types.ts
+++ b/x-pack/plugins/security_solution/public/app/types.ts
@@ -12,7 +12,6 @@ import {
   Action,
   Store,
   Dispatch,
-  PreloadedState,
   StateFromReducersMapObject,
   CombinedState,
 } from 'redux';
@@ -39,7 +38,7 @@ import { TimelineState } from '../timelines/store/timeline/types';
 export { SecurityPageName } from '../../common/constants';
 
 export interface SecuritySubPluginStore<K extends SecuritySubPluginKeyStore, T> {
-  initialState: Record<K, T | undefined>;
+  initialState: Record<K, T>;
   reducer: Record<K, Reducer<T, AnyAction>>;
   middleware?: Array<Middleware<{}, State, Dispatch<AppAction | Immutable<AppAction>>>>;
 }
@@ -70,14 +69,12 @@ export interface SecuritySubPluginWithStore<K extends SecuritySubPluginKeyStore,
 
 export interface SecuritySubPlugins extends SecuritySubPlugin {
   store: {
-    initialState: PreloadedState<
-      CombinedState<
-        StateFromReducersMapObject<
-          /** SubPluginsInitReducer, being an interface, will not work in `StateFromReducersMapObject`.
-           * Picking its keys does the trick.
-           **/
-          Pick<SubPluginsInitReducer, keyof SubPluginsInitReducer>
-        >
+    initialState: CombinedState<
+      StateFromReducersMapObject<
+        /** SubPluginsInitReducer, being an interface, will not work in `StateFromReducersMapObject`.
+         * Picking its keys does the trick.
+         **/
+        Pick<SubPluginsInitReducer, keyof SubPluginsInitReducer>
       >
     >;
     reducer: SubPluginsInitReducer;

--- a/x-pack/plugins/security_solution/public/common/store/reducer.test.ts
+++ b/x-pack/plugins/security_solution/public/common/store/reducer.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseExperimentalConfigValue } from '../../..//common/experimental_features';
+import { SecuritySubPlugins } from '../../app/types';
 import { createInitialState } from './reducer';
 
 jest.mock('../lib/kibana', () => ({
@@ -16,30 +17,28 @@ jest.mock('../lib/kibana', () => ({
 
 describe('createInitialState', () => {
   describe('sourcerer -> default -> indicesExist', () => {
+    const mockPluginState = {} as Omit<
+      SecuritySubPlugins['store']['initialState'],
+      'app' | 'dragAndDrop' | 'inputs' | 'sourcerer'
+    >;
     test('indicesExist should be TRUE if configIndexPatterns is NOT empty', () => {
-      const initState = createInitialState(
-        {},
-        {
-          kibanaIndexPatterns: [{ id: '1234567890987654321', title: 'mock-kibana' }],
-          configIndexPatterns: ['auditbeat-*', 'filebeat'],
-          signalIndexName: 'siem-signals-default',
-          enableExperimental: parseExperimentalConfigValue([]),
-        }
-      );
+      const initState = createInitialState(mockPluginState, {
+        kibanaIndexPatterns: [{ id: '1234567890987654321', title: 'mock-kibana' }],
+        configIndexPatterns: ['auditbeat-*', 'filebeat'],
+        signalIndexName: 'siem-signals-default',
+        enableExperimental: parseExperimentalConfigValue([]),
+      });
 
       expect(initState.sourcerer?.sourcererScopes.default.indicesExist).toEqual(true);
     });
 
     test('indicesExist should be FALSE if configIndexPatterns is empty', () => {
-      const initState = createInitialState(
-        {},
-        {
-          kibanaIndexPatterns: [{ id: '1234567890987654321', title: 'mock-kibana' }],
-          configIndexPatterns: [],
-          signalIndexName: 'siem-signals-default',
-          enableExperimental: parseExperimentalConfigValue([]),
-        }
-      );
+      const initState = createInitialState(mockPluginState, {
+        kibanaIndexPatterns: [{ id: '1234567890987654321', title: 'mock-kibana' }],
+        configIndexPatterns: [],
+        signalIndexName: 'siem-signals-default',
+        enableExperimental: parseExperimentalConfigValue([]),
+      });
 
       expect(initState.sourcerer?.sourcererScopes.default.indicesExist).toEqual(false);
     });

--- a/x-pack/plugins/security_solution/public/common/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/reducer.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { combineReducers, PreloadedState, AnyAction, Reducer } from 'redux';
+import { combineReducers, AnyAction, Reducer } from 'redux';
 
 import { appReducer, initialAppState } from './app';
 import { dragAndDropReducer, initialDragAndDropState } from './drag_and_drop';
@@ -34,7 +34,10 @@ export type SubPluginsInitReducer = HostsPluginReducer &
  * Factory for the 'initialState' that is used to preload state into the Security App's redux store.
  */
 export const createInitialState = (
-  pluginsInitState: SecuritySubPlugins['store']['initialState'],
+  pluginsInitState: Omit<
+    SecuritySubPlugins['store']['initialState'],
+    'app' | 'dragAndDrop' | 'inputs' | 'sourcerer'
+  >,
   {
     kibanaIndexPatterns,
     configIndexPatterns,
@@ -46,11 +49,11 @@ export const createInitialState = (
     signalIndexName: string | null;
     enableExperimental: ExperimentalFeatures;
   }
-): PreloadedState<State> => {
-  const preloadedState: PreloadedState<State> = {
+): State => {
+  const preloadedState: State = {
+    ...pluginsInitState,
     app: { ...initialAppState, enableExperimental },
     dragAndDrop: initialDragAndDropState,
-    ...pluginsInitState,
     inputs: createInitialInputsState(),
     sourcerer: {
       ...sourcererModel.initialSourcererState,
@@ -66,6 +69,7 @@ export const createInitialState = (
       signalIndexName,
     },
   };
+
   return preloadedState;
 };
 

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/model.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/model.ts
@@ -27,7 +27,7 @@ export interface ManageScope {
   docValueFields: DocValueFields[];
   errorMessage: string | null;
   id: SourcererScopeName;
-  indexPattern: IIndexPattern;
+  indexPattern: Omit<IIndexPattern, 'fieldFormatMap'>;
   indicesExist: boolean | undefined | null;
   loading: boolean;
   selectedPatterns: string[];
@@ -37,9 +37,7 @@ export interface ManageScopeInit extends Partial<ManageScope> {
   id: SourcererScopeName;
 }
 
-export type SourcererScopeById = {
-  [id in SourcererScopeName]: ManageScope;
-};
+export type SourcererScopeById = Record<SourcererScopeName | string, ManageScope>;
 
 export type KibanaIndexPatterns = Array<{ id: string; title: string }>;
 
@@ -51,7 +49,16 @@ export interface SourcererModel {
   sourcererScopes: SourcererScopeById;
 }
 
-export const initSourcererScope = {
+export const initSourcererScope: Pick<
+  ManageScope,
+  | 'browserFields'
+  | 'docValueFields'
+  | 'errorMessage'
+  | 'indexPattern'
+  | 'indicesExist'
+  | 'loading'
+  | 'selectedPatterns'
+> = {
   browserFields: EMPTY_BROWSER_FIELDS,
   docValueFields: EMPTY_DOCVALUE_FIELD,
   errorMessage: null,

--- a/x-pack/plugins/security_solution/public/common/store/store.ts
+++ b/x-pack/plugins/security_solution/public/common/store/store.ts
@@ -49,7 +49,7 @@ let store: Store<State, Action> | null = null;
  * Factory for Security App's redux store.
  */
 export const createStore = (
-  state: PreloadedState<State>,
+  state: State,
   pluginsReducer: SubPluginsInitReducer,
   kibana: Observable<CoreStart>,
   storage: Storage,
@@ -74,7 +74,7 @@ export const createStore = (
 
   store = createReduxStore(
     createReducer(pluginsReducer),
-    state,
+    state as PreloadedState<State>,
     composeEnhancers(
       applyMiddleware(epicMiddleware, telemetryMiddleware, ...(additionalMiddleware ?? []))
     )

--- a/x-pack/plugins/security_solution/public/management/index.ts
+++ b/x-pack/plugins/security_solution/public/management/index.ts
@@ -42,13 +42,18 @@ export class Management {
       routes,
       store: {
         initialState: {
-          management: undefined,
+          /**
+           * Cast the state to ManagementState for compatibility with
+           * the subplugin architecture (which expects initialize state.)
+           * but you do not need it because this plugin is doing it through its middleware
+           */
+          management: {} as ManagementState,
         },
         /**
          * Cast the ImmutableReducer to a regular reducer for compatibility with
          * the subplugin architecture (which expects plain redux reducers.)
          */
-        reducer: { management: managementReducer } as ManagementPluginReducer,
+        reducer: { management: managementReducer } as unknown as ManagementPluginReducer,
         middleware: managementMiddlewareFactory(core, plugins),
       },
     };

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -292,7 +292,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         cases: new subPluginClasses.Cases(),
         hosts: new subPluginClasses.Hosts(),
         network: new subPluginClasses.Network(),
-        ...(this.experimentalFeatures.uebaEnabled ? { ueba: new subPluginClasses.Ueba() } : {}),
+        ueba: new subPluginClasses.Ueba(),
         overview: new subPluginClasses.Overview(),
         timelines: new subPluginClasses.Timelines(),
         management: new subPluginClasses.Management(),
@@ -318,9 +318,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       cases: subPlugins.cases.start(),
       hosts: subPlugins.hosts.start(storage),
       network: subPlugins.network.start(storage),
-      ...(this.experimentalFeatures.uebaEnabled && subPlugins.ueba != null
-        ? { ueba: subPlugins.ueba.start(storage) }
-        : {}),
+      ueba: subPlugins.ueba.start(storage),
       timelines: subPlugins.timelines.start(),
       management: subPlugins.management.start(core, plugins),
     };
@@ -374,7 +372,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         timeline: {
           ...subPlugins.timelines.store.initialState.timeline!,
           timelineById: {
-            ...subPlugins.timelines.store.initialState.timeline!.timelineById,
+            ...subPlugins.timelines.store.initialState.timeline.timelineById,
             ...subPlugins.alerts.storageTimelines!.timelineById,
             ...subPlugins.rules.storageTimelines!.timelineById,
             ...subPlugins.exceptions.storageTimelines!.timelineById,
@@ -399,9 +397,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
           {
             ...subPlugins.hosts.store.initialState,
             ...subPlugins.network.store.initialState,
-            ...(this.experimentalFeatures.uebaEnabled && subPlugins.ueba != null
-              ? subPlugins.ueba.store.initialState
-              : {}),
+            ...subPlugins.ueba.store.initialState,
             ...timelineInitialState,
             ...subPlugins.management.store.initialState,
           },

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -94,8 +94,7 @@ export interface SubPlugins {
   cases: Cases;
   hosts: Hosts;
   network: Network;
-  // TODO: Steph/ueba require ueba once no longer experimental
-  ueba?: Ueba;
+  ueba: Ueba;
   overview: Overview;
   timelines: Timelines;
   management: Management;
@@ -109,8 +108,7 @@ export interface StartedSubPlugins {
   cases: ReturnType<Cases['start']>;
   hosts: ReturnType<Hosts['start']>;
   network: ReturnType<Network['start']>;
-  // TODO: Steph/ueba require ueba once no longer experimental
-  ueba?: ReturnType<Ueba['start']>;
+  ueba: ReturnType<Ueba['start']>;
   overview: ReturnType<Overview['start']>;
   timelines: ReturnType<Timelines['start']>;
   management: ReturnType<Management['start']>;

--- a/x-pack/plugins/timelines/common/search_strategy/index_fields/index.ts
+++ b/x-pack/plugins/timelines/common/search_strategy/index_fields/index.ts
@@ -67,12 +67,7 @@ export interface BrowserField {
   name: string;
   searchable: boolean;
   type: string;
-  subType?: {
-    [key: string]: unknown;
-    nested?: {
-      path: string;
-    };
-  };
+  subType?: IFieldSubType;
 }
 
 export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;

--- a/x-pack/plugins/timelines/common/types/timeline/index.ts
+++ b/x-pack/plugins/timelines/common/types/timeline/index.ts
@@ -468,7 +468,7 @@ export enum TimelineTabs {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type EmptyObject = Record<any, never>;
+type EmptyObject = Partial<Record<any, never>>;
 
 export type TimelineExpandedEventType =
   | {
@@ -512,9 +512,9 @@ export type TimelineExpandedDetailType =
   | TimelineExpandedHostType
   | TimelineExpandedNetworkType;
 
-export type TimelineExpandedDetail = {
-  [tab in TimelineTabs]?: TimelineExpandedDetailType;
-};
+export type TimelineExpandedDetail = Partial<
+  Record<TimelineTabs | string, TimelineExpandedDetailType>
+>;
 
 export type ToggleDetailPanel = TimelineExpandedDetailType & {
   tabType?: TimelineTabs;

--- a/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
@@ -420,7 +420,7 @@ export const updateTimelineDetailsPanel = (action: ToggleDetailPanel): TimelineE
   const panelViewOptions = new Set(['eventDetail', 'hostDetail', 'networkDetail']);
   const expandedTabType = tabType ?? TimelineTabs.query;
   const newExpandDetails = {
-    params: expandedDetails.params ? { ...expandedDetails.params } : undefined,
+    params: expandedDetails.params ? { ...expandedDetails.params } : {},
     panelView: expandedDetails.panelView,
   } as TimelineExpandedDetailType;
   return {

--- a/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
@@ -16,6 +16,8 @@ import type {
   ColumnHeaderOptions,
   DataProvider,
   SortColumnTimeline,
+  TimelineExpandedDetail,
+  TimelineExpandedDetailType,
 } from '../../../common/types/timeline';
 import { getTGridManageDefaults, tGridDefaults } from './defaults';
 
@@ -412,22 +414,20 @@ export const setSelectedTimelineEvents = ({
   };
 };
 
-export const updateTimelineDetailsPanel = (action: ToggleDetailPanel) => {
-  const { tabType } = action;
+export const updateTimelineDetailsPanel = (action: ToggleDetailPanel): TimelineExpandedDetail => {
+  const { tabType, timelineId, ...expandedDetails } = action;
 
   const panelViewOptions = new Set(['eventDetail', 'hostDetail', 'networkDetail']);
   const expandedTabType = tabType ?? TimelineTabs.query;
-
-  return action.panelView && panelViewOptions.has(action.panelView)
-    ? {
-        [expandedTabType]: {
-          params: action.params ? { ...action.params } : {},
-          panelView: action.panelView,
-        },
-      }
-    : {
-        [expandedTabType]: {},
-      };
+  const newExpandDetails = {
+    params: expandedDetails.params ? { ...expandedDetails.params } : undefined,
+    panelView: expandedDetails.panelView,
+  } as TimelineExpandedDetailType;
+  return {
+    [expandedTabType]: panelViewOptions.has(expandedDetails.panelView ?? '')
+      ? newExpandDetails
+      : {},
+  };
 };
 
 export const addProviderToTimelineHelper = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -23572,7 +23572,7 @@ redux-thunks@^1.0.0:
   resolved "https://registry.yarnpkg.com/redux-thunks/-/redux-thunks-1.0.0.tgz#56e03b86d281a2664c884ab05c543d9ab1673658"
   integrity sha1-VuA7htKBomZMiEqwXFQ9mrFnNlg=
 
-redux@^4.0.0, redux@^4.0.4, redux@^4.0.5, redux@^4.1.0:
+redux@^4.0.0, redux@^4.0.4, redux@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"
   integrity sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==


### PR DESCRIPTION
Fix types from bumping immer.

The main problem was with `PreloadedState` type
```
export type PreloadedState<S> = Required<S> extends EmptyObject
  ? S extends CombinedState<infer S1>
    ? {
        [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]
      }
    : never
  : {
      [K in keyof S]: S[K] extends string | number | boolean | symbol
        ? S[K]
        : PreloadedState<S[K]>
    }
 ```
 before it looks like that 
 ```
export type PreloadedState<S> = Required<S> extends EmptyObject
  ? S extends CombinedState<infer S1>
    ? {
        [K in keyof S1]?: S1[K] extends object ? PreloadedState<S1[K]> : S1[K]
      }
    : never
  : {
      [K in keyof S]: S[K] extends object
        ? PreloadedState<S[K]>
        : S[K]
    }
```